### PR TITLE
add API to set snap configuration

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -23,5 +23,11 @@ jobs:
         run: |
           sudo apt install -y snapd
           sudo systemctl start snapd.service
+      - name: build test_snap
+        run: |
+          sudo snap install snapcraft --classic
+          cd tests/integration/test_snap
+          snapcraft --destructive-mode
+          cd $GITHUB_WORKSPACE
       - name: integration test
         run: sudo poetry run pytest tests/integration

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,8 +48,8 @@ jobs:
         os: ["ubuntu-22.04", "ubuntu-20.04"]
     runs-on: ${{ matrix.os }}
     steps:
-        # Access to the snapd socket requires root privileges, so these
-        # tests need to be run as root.
+      # Access to the snapd socket requires root privileges, so these
+      # tests need to be run as root.
       - uses: actions/checkout@v4
       - name: install python dependencies
         run: |
@@ -59,7 +59,13 @@ jobs:
           sudo poetry install
       - name: snapd setup
         run: |
-          sudo apt install -y snapd
+          sudo apt-get install -y snapd
           sudo systemctl start snapd.service
+      - name: build test_snap
+        run: |
+          sudo snap install snapcraft --classic
+          cd tests/integration/test_snap
+          snapcraft --destructive-mode
+          cd ../../../
       - name: integration test
         run: sudo poetry run pytest tests/integration

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ htmlcov
 **/__pycache__/
 .coverage
 dist/
+
+*.snap

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: test_snap
+.ONESHELL:
+test_snap:
+	cd tests/integration/test_snap
+	snapcraft --debug

--- a/snap_http/__init__.py
+++ b/snap_http/__init__.py
@@ -21,6 +21,7 @@ from .api import (
     unhold_all,
     list,
     get_conf,
+    set_conf,
 )
 
 from .http import SnapdHttpException

--- a/snap_http/__init__.py
+++ b/snap_http/__init__.py
@@ -32,4 +32,7 @@ from .types import (
     SUCCESS_STATUSES,
     ERROR_STATUSES,
     SnapdResponse,
+    FormData,
+    JsonData,
+    FileUpload,
 )

--- a/snap_http/api.py
+++ b/snap_http/api.py
@@ -5,7 +5,7 @@ See https://snapcraft.io/docs/snapd-api for documentation of the API.
 Permissions are based on the user calling the API, most mutative interactions
 (install, refresh, etc) require root.
 """
-from typing import Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from . import http
 from .types import SnapdResponse
@@ -217,6 +217,14 @@ def list() -> SnapdResponse:
     return http.get("/snaps")
 
 
+# Configuration: get and set snap options
+
+
 def get_conf(name: str) -> SnapdResponse:
     """Get the configuration details for the snap `name`."""
     return http.get(f"/snaps/{name}/conf")
+
+
+def set_conf(name: str, config: Dict[str, Any]) -> SnapdResponse:
+    """Set the configuration details for the snap `name`."""
+    return http.put(f"/snaps/{name}/conf", config)

--- a/snap_http/types.py
+++ b/snap_http/types.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import json
+from abc import ABC, abstractproperty
 from dataclasses import dataclass
 from functools import cached_property
+from io import BytesIO
 from pathlib import Path
-from typing import Any, Dict, List, Type, Union
+from typing import Any, Dict, List, Optional, Type, Union
+from uuid import uuid4
 
 
 # For the below, refer to https://snapcraft.io/docs/snapd-api#heading--changes
@@ -11,6 +15,8 @@ COMPLETE_STATUSES = {"Done", "Error", "Hold", "Abort"}
 INCOMPLETE_STATUSES = {"Do", "Doing", "Undo", "Undoing"}
 SUCCESS_STATUSES = {"Done"}
 ERROR_STATUSES = {"Error", "Hold", "Unknown"}
+
+SnapdRequestBody = Union[Dict[str, Any], "JsonData", "FormData"]
 
 
 @dataclass
@@ -30,6 +36,91 @@ class SnapdResponse:
     @classmethod
     def from_http_response(cls: Type, response: Dict[str, Any]) -> SnapdResponse:
         return cls(**{k.replace("-", "_"): v for k, v in response.items()})
+
+
+class AbstractRequestBody(ABC):
+    """An abstract base class for the request body of a HTTP request."""
+
+    content_type: str
+
+    def __init__(self, data: Dict[str, Any]) -> None:
+        """Initialize the class with `data`."""
+        self.data = data
+
+    @abstractproperty
+    def serialized(self) -> bytes:
+        """Serialize the request body based on the `content_type`."""
+
+    @cached_property
+    def content_length(self) -> int:
+        """Get the length of the serialized request body."""
+        return len(self.serialized)
+
+    @cached_property
+    def content_type_header(self) -> str:
+        """Get the content type header value."""
+        return self.content_type
+
+
+class JsonData(AbstractRequestBody):
+    """A `SnapdRequestBody` that is serialized to the application/json content type."""
+
+    content_type = "application/json"
+
+    @cached_property
+    def serialized(self) -> bytes:
+        """Serialize the request body to byte-encoded JSON."""
+        return json.dumps(self.data).encode()
+
+
+class FormData(AbstractRequestBody):
+    """A `SnapdRequestBody` that is serialized to the multipart/form-data content type."""
+
+    content_type = "multipart/form-data"
+    files: List[FileUpload]
+    boundary: str
+
+    def __init__(
+        self,
+        data: Dict[str, Any],
+        files: Optional[List["FileUpload"]] = None,
+    ) -> None:
+        """Initialize the class."""
+        super().__init__(data)
+        self.files = files or []
+        self.boundary = str(uuid4())
+
+    @cached_property
+    def serialized(self) -> bytes:
+        """Serialize the request data & files to the multipart/form-data format."""
+        content = BytesIO()
+        for key, value in self.data.items():
+            content.write(
+                (
+                    f"--{self.boundary}\r\n"
+                    f'Content-Disposition: form-data; name="{key}"\r\n\r\n'
+                    f"{value}\r\n"
+                ).encode()
+            )
+
+        for file in self.files:
+            content.write(
+                (
+                    f"--{self.boundary}\r\n"
+                    f'Content-Disposition: form-data; name="{file.name}"; '
+                    f'filename="{file.filename}"\r\n\r\n'
+                ).encode()
+            )
+            content.write(file.content)
+            content.write(b"\r\n")
+
+        content.write(f"--{self.boundary}--\r\n".encode())
+        return content.getvalue()
+
+    @cached_property
+    def content_type_header(self) -> str:
+        """Get the content type header value."""
+        return f"{self.content_type}; boundary={self.boundary}"
 
 
 @dataclass

--- a/snap_http/types.py
+++ b/snap_http/types.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import cached_property
+from pathlib import Path
 from typing import Any, Dict, List, Type, Union
 
 
@@ -28,3 +30,22 @@ class SnapdResponse:
     @classmethod
     def from_http_response(cls: Type, response: Dict[str, Any]) -> SnapdResponse:
         return cls(**{k.replace("-", "_"): v for k, v in response.items()})
+
+
+@dataclass
+class FileUpload:
+    """A file to upload to snapd's REST API."""
+
+    name: str
+    path: str
+
+    @cached_property
+    def filename(self) -> str:
+        """Return the filename."""
+        return Path(self.path).name
+
+    @cached_property
+    def content(self) -> bytes:
+        """Read and return the file's binary content."""
+        with open(self.path, "rb") as f:
+            return f.read()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,18 +1,27 @@
 import pytest
 
-from tests.utils import call_and_await_api, is_snap_installed
+import snap_http
+
+from tests.utils import is_snap_installed, sideload_snap, wait_for
+
+TEST_SNAPS = ["test-snap", "hello-world"]
+LOCAL_TEST_SNAP_PATH = "tests/integration/test_snap/test-snap_perpetual_amd64.snap"
 
 
 def pytest_configure():
-    """Make sure the test snap is not installed before running any tests."""
-    if is_snap_installed("hello-world"):
-        call_and_await_api("remove", "hello-world")
+    """Make sure the test environment is clean before running tests."""
+    # remove test snaps if they exist
+    installed = {snap["name"] for snap in snap_http.list().result}
+    for snap in TEST_SNAPS:
+        if snap in installed:
+            wait_for(snap_http.remove)(snap)
 
 
 @pytest.fixture(scope="function")
 def test_snap():
-    yield call_and_await_api("install", "hello-world")
+    """Install the test snap."""
+    yield sideload_snap(LOCAL_TEST_SNAP_PATH)
 
     # teardown
-    if is_snap_installed("hello-world"):
-        call_and_await_api("remove", "hello-world")
+    if is_snap_installed("test-snap"):
+        wait_for(snap_http.remove)("test-snap")

--- a/tests/integration/test_snap/setup.py
+++ b/tests/integration/test_snap/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup
+
+setup(
+    name="test_snap",
+    description="A test snap",
+    license="GPL-2.0",
+    python_requires=">=3.8",
+    packages=["test_snap"],
+    entry_points={
+        "console_scripts": ["test-snap=test_snap.main:main"],
+    },
+)

--- a/tests/integration/test_snap/snap/hooks/configure
+++ b/tests/integration/test_snap/snap/hooks/configure
@@ -1,0 +1,17 @@
+#!/bin/sh -e
+
+DEFAULT_BAR="default"
+DEFAULT_BAZ="default"
+
+bar="$(snapctl get foo.bar)"
+if [ -z "$bar" ]; then
+    bar="$DEFAULT_BAR"
+fi
+
+baz="$(snapctl get foo.baz)"
+if [ -z "$baz" ]; then
+    baz="$DEFAULT_BAZ"
+fi
+
+snapctl set foo.bar="$bar"
+snapctl set foo.baz="$baz"

--- a/tests/integration/test_snap/snap/hooks/default-configure
+++ b/tests/integration/test_snap/snap/hooks/default-configure
@@ -1,0 +1,1 @@
+configure

--- a/tests/integration/test_snap/snap/snapcraft.yaml
+++ b/tests/integration/test_snap/snap/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: test-snap
+base: core22
+version: perpetual
+summary: A test snap
+description: |
+  A snap to make integration tests easier to do.
+
+grade: devel
+confinement: devmode
+
+apps:
+  pocketses:
+    command: bin/test-snap
+
+parts:
+  test-snap:
+    plugin: python
+    source: .
+    parse-info:
+      - setup.py

--- a/tests/integration/test_snap/test_snap/__main__.py
+++ b/tests/integration/test_snap/test_snap/__main__.py
@@ -1,0 +1,3 @@
+from .main import main
+
+main()

--- a/tests/integration/test_snap/test_snap/main.py
+++ b/tests/integration/test_snap/test_snap/main.py
@@ -1,0 +1,2 @@
+def main() -> None:
+    print("Hello World!")

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -806,3 +806,25 @@ def test_get_conf(monkeypatch):
     result = api.get_conf("placeholder")
 
     assert result == mock_response
+
+
+def test_set_conf(monkeypatch):
+    """`api.set_conf` returns a `types.SnapdResponse`."""
+    mock_response = types.SnapdResponse(
+        type="async",
+        status_code=202,
+        status="Accepted",
+        result=None,
+        change="1",
+    )
+
+    def mock_put(path, _):
+        assert path == "/snaps/placeholder/conf"
+
+        return mock_response
+
+    monkeypatch.setattr(http, "put", mock_put)
+
+    result = api.set_conf("placeholder", {"foo": "bar"})
+
+    assert result == mock_response

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -183,12 +183,10 @@ def test_making_multipart_request(use_snapd_response, monkeypatch):
     receiver, thread = use_snapd_response(202, mock_response)
 
     with tempfile.NamedTemporaryFile() as tmp:
+        data = {"action": "install", "devmode": "true"}
         file = types.FileUpload(name="snap", path=tmp.name)
-        result = http._make_request(
-            "/snaps",
-            "POST",
-            form_data={"action": "install"},
-            files=[file],
+        result =http._make_request(
+            "/snaps", "POST", body=types.FormData(data=data, files=[file])
         )
 
     assert result == mock_response

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -34,12 +34,9 @@ def is_snap_installed(snap_name: str) -> bool:
 @wait_for
 def sideload_snap(file_path: str) -> bool:
     """Sideload a snap from the local filesystem."""
-    form_data = {"action": "install", "devmode": "true"}
-    file = snap_http.types.FileUpload(name="snap", path=file_path)
+    data = {"action": "install", "devmode": "true"}
+    file = snap_http.FileUpload(name="snap", path=file_path)
     response = snap_http.http._make_request(
-        "/snaps",
-        "POST",
-        form_data=form_data,
-        files=[file],
+        "/snaps", "POST", body=snap_http.FormData(data=data, files=[file])
     )
     return snap_http.SnapdResponse.from_http_response(response)

--- a/tox.ini
+++ b/tox.ini
@@ -14,4 +14,4 @@ allowlist_externals =
 commands_pre =
     poetry install
 commands =
-    poetry run pytest tests/unit --cov snap_http/ --cov-branch --import-mode importlib
+    poetry run pytest tests/unit --cov snap_http/ --cov-branch --cov-report term-missing --import-mode importlib


### PR DESCRIPTION
This PR adds the API to set a snap's configuration.

For integration testing, I had to write a small snap that allows setting configuration since the `hello-world` snap doesn't. The local snap is being sideloaded using a `multipart/form-data` request.
