### PR TITLE
get and set specific config values

### DIFF
--- a/snap_http/api.py
+++ b/snap_http/api.py
@@ -264,11 +264,25 @@ def list() -> SnapdResponse:
 # Configuration: get and set snap options
 
 
-def get_conf(name: str) -> SnapdResponse:
-    """Get the configuration details for the snap `name`."""
-    return http.get(f"/snaps/{name}/conf")
+def get_conf(name: str, *, keys: Optional[List[str]] = None) -> SnapdResponse:
+    """Get the configuration details for the snap `name`.
+
+    :param name: the name of the snap.
+    :param keys: retrieve the configuration for these specific `keys`. Dotted
+        keys can be used to retrieve nested values.
+    """
+    query_params = {}
+    if keys:
+        query_params["keys"] = ",".join(keys)
+
+    return http.get(f"/snaps/{name}/conf", query_params=query_params)
 
 
 def set_conf(name: str, config: Dict[str, Any]) -> SnapdResponse:
-    """Set the configuration details for the snap `name`."""
+    """Set the configuration details for the snap `name`.
+
+    :param name: the name of the snap.
+    :param config: A key-value mapping of snap configuration.
+        Keys can be dotted, `None` can be used to unset config options.
+    """
     return http.put(f"/snaps/{name}/conf", config)

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -10,21 +10,119 @@ def test_get_config(test_snap):
     """Test getting snap configuration."""
     response = snap_http.get_conf("test-snap")
     assert response.status_code == 200
-    assert response.result == {"foo": {"bar": "default", "baz": "default"}}
+    assert response.result == {
+        "foo": {"bar": "default", "baz": "default"},
+        "port": 8080,
+    }
+
+
+def test_get_specific_config_value(test_snap):
+    """Test getting specific snap configuration."""
+    response = snap_http.get_conf("test-snap", keys=["port"])
+    assert response.status_code == 200
+    assert response.result == {"port": 8080}
+
+
+def test_get_nested_config_value(test_snap):
+    """Test getting a specific nested snap configuration."""
+    response = snap_http.get_conf("test-snap", keys=["foo.bar"])
+    assert response.status_code == 200
+    assert response.result == {"foo.bar": "default"}
 
 
 def test_set_config(test_snap):
     """Test setting snap configuration."""
     before = snap_http.get_conf("test-snap")
-    assert before.result == {"foo": {"bar": "default", "baz": "default"}}
+    assert before.result == {
+        "foo": {"bar": "default", "baz": "default"},
+        "port": 8080,
+    }
 
     response = wait_for(snap_http.set_conf)(
-        "test-snap", {"foo": {"bar": "qux", "baz": "quux"}}
+        "test-snap",
+        {
+            "foo": {"bar": "qux", "baz": "quux"},
+            "port": 8080,
+        },
     )
     assert response.status_code == 202
 
     after = snap_http.get_conf("test-snap")
-    assert after.result == {"foo": {"bar": "qux", "baz": "quux"}}
+    assert after.result == {
+        "foo": {"bar": "qux", "baz": "quux"},
+        "port": 8080,
+    }
+
+
+def test_set_specific_config_value(test_snap):
+    """Test setting specific snap configuration."""
+    before = snap_http.get_conf("test-snap")
+    assert before.result == {
+        "foo": {"bar": "default", "baz": "default"},
+        "port": 8080,
+    }
+
+    response = wait_for(snap_http.set_conf)(
+        "test-snap",
+        {"port": 443, "foo.baz": "lambda"},
+    )
+    assert response.status_code == 202
+
+    after = snap_http.get_conf("test-snap")
+    assert after.result == {
+        "foo": {"bar": "default", "baz": "lambda"},
+        "port": 443,
+    }
+
+
+def test_set_config_with_invalid_key(test_snap):
+    """Test setting config with an invalid key."""
+    before = snap_http.get_conf("test-snap")
+    assert before.result == {
+        "foo": {"bar": "default", "baz": "default"},
+        "port": 8080,
+    }
+
+    response = wait_for(snap_http.set_conf)("test-snap", {"foo /bar": 80})
+    assert response.status_code == 202
+
+    change = snap_http.check_change(response.change).result
+    assert change["status"] == "Error"
+    assert 'invalid option name: "foo /bar"' in change["err"]
+
+    # confirm settings haven't changed
+    after = snap_http.get_conf("test-snap")
+    assert after.result == {
+        "foo": {"bar": "default", "baz": "default"},
+        "port": 8080,
+    }
+
+
+def test_unset_config_value(test_snap):
+    """Test unsetting snap configuration."""
+    before = snap_http.get_conf("test-snap")
+    assert before.result == {
+        "foo": {"bar": "default", "baz": "default"},
+        "port": 8080,
+    }
+
+    response = wait_for(snap_http.set_conf)(
+        "test-snap",
+        {"foo.bar": "meta"},
+    )
+    assert response.status_code == 202
+
+    after = snap_http.get_conf("test-snap", keys=["foo.bar"])
+    assert after.result == {"foo.bar": "meta"}
+
+    response = wait_for(snap_http.set_conf)(
+        "test-snap",
+        {"foo.bar": None},
+    )
+    assert response.status_code == 202
+
+    after_unset = snap_http.get_conf("test-snap", keys=["foo.bar"])
+    assert after_unset.result == {"foo.bar": "default"}
 
 
 # snaps: list and manage installed snaps

--- a/tests/integration/test_snap/snap/hooks/configure
+++ b/tests/integration/test_snap/snap/hooks/configure
@@ -2,6 +2,7 @@
 
 DEFAULT_BAR="default"
 DEFAULT_BAZ="default"
+DEFAULT_PORT=8080
 
 bar="$(snapctl get foo.bar)"
 if [ -z "$bar" ]; then
@@ -13,5 +14,11 @@ if [ -z "$baz" ]; then
     baz="$DEFAULT_BAZ"
 fi
 
+port="$(snapctl get port)"
+if [ -z "$port"]; then
+    port="$DEFAULT_PORT"
+fi
+
 snapctl set foo.bar="$bar"
 snapctl set foo.baz="$baz"
+snapctl set port="$port"

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -989,7 +989,7 @@ def test_get_conf(monkeypatch):
         result={},
     )
 
-    def mock_get(path):
+    def mock_get(path, query_params):
         assert path == "/snaps/placeholder/conf"
 
         return mock_response
@@ -997,6 +997,27 @@ def test_get_conf(monkeypatch):
     monkeypatch.setattr(http, "get", mock_get)
 
     result = api.get_conf("placeholder")
+
+    assert result == mock_response
+
+
+def test_get_specific_config_values(monkeypatch):
+    """`api.get_conf` returns a `types.SnapdResponse`."""
+    mock_response = types.SnapdResponse(
+        type="sync",
+        status_code=200,
+        status="OK",
+        result={"foo.bar": "default", "port": 8080},
+    )
+
+    def mock_get(path, query_params):
+        assert path == "/snaps/placeholder/conf"
+
+        return mock_response
+
+    monkeypatch.setattr(http, "get", mock_get)
+
+    result = api.get_conf("placeholder", keys=["foo.bar", "port"])
 
     assert result == mock_response
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,4 +14,5 @@ allowlist_externals =
 commands_pre =
     poetry install
 commands =
-    poetry run pytest tests/unit --cov snap_http/ --cov-branch --cov-report term-missing --import-mode importlib
+    poetry run pytest tests/unit --cov snap_http/ --cov-branch \
+        --cov-report term-missing --cov-fail-under 92 --import-mode importlib


### PR DESCRIPTION
This PR allows us to get and set specific configuration keys/values.


Also bumps the required test coverage to 91%, we'll slowly bump this towards 100% with time (the missing coverage is for the snap refresh code). Coverage report:

```
collected 50 items

tests/unit/test_api.py ..........................................        [ 84%]
tests/unit/test_http.py ........                                         [100%]

---------- coverage: platform linux, python 3.8.18-final-0 -----------
Name                    Stmts   Miss Branch BrPart  Cover   Missing
-------------------------------------------------------------------
snap_http/__init__.py       3      0      0      0   100%
snap_http/api.py           74     12     20      0    79%   125-136, 143-148
snap_http/http.py          42      0      8      0   100%
snap_http/types.py         75      0     10      0   100%
-------------------------------------------------------------------
TOTAL                     194     12     38      0    91%

Required test coverage of 91% reached. Total coverage: 91.38%
```