### PR TITLE
add: getting, creating, and removing users

### DIFF
--- a/snap_http/__init__.py
+++ b/snap_http/__init__.py
@@ -26,6 +26,9 @@ from .api import (
     get_assertion_types,
     get_assertions,
     add_assertion,
+    list_users,
+    add_user,
+    remove_user,
 )
 
 from .http import SnapdHttpException

--- a/snap_http/api.py
+++ b/snap_http/api.py
@@ -5,6 +5,7 @@ See https://snapcraft.io/docs/snapd-api for documentation of the API.
 Permissions are based on the user calling the API, most mutative interactions
 (install, refresh, etc) require root.
 """
+
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from . import http
@@ -319,3 +320,38 @@ def add_assertion(assertion: str) -> SnapdResponse:
     """
     body = AssertionData(assertion)
     return http.post("/assertions", body)
+
+
+# Users
+
+
+def list_users() -> SnapdResponse:
+    """Get information on user accounts."""
+    return http.get("/users")
+
+
+def add_user(
+    username: str,
+    email: str,
+    sudoer: bool = False,
+    known: bool = False,
+    force_managed: bool = False,
+    automatic: bool = False,
+) -> SnapdResponse:
+    """Create a local user."""
+    body = {
+        "action": "create",
+        "username": username,
+        "email": email,
+        "sudoer": sudoer,
+        "known": known,
+        "force-managed": force_managed,
+        "automatic": automatic,
+    }
+    return http.post("/users", body)
+
+
+def remove_user(username: str) -> SnapdResponse:
+    """Remove a local user."""
+    body = {"action": "remove", "username": username}
+    return http.post("/users", body)

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1146,3 +1146,109 @@ def test_add_assertion_exception(monkeypatch):
 
     with pytest.raises(http.SnapdHttpException):
         api.add_assertion("not an assertion")
+
+
+def test_list_users(monkeypatch):
+    """`api.list_users` returns a `types.SnapdResponse`."""
+    mock_response = types.SnapdResponse(
+        type="sync",
+        status_code=200,
+        status="OK",
+        result=[{"id": 1, "username": "john", "email": "john.doe@example.com"}],
+    )
+
+    def mock_get(path):
+        assert path == "/users"
+
+        return mock_response
+
+    monkeypatch.setattr(http, "get", mock_get)
+
+    result = api.list_users()
+    assert result == mock_response
+
+
+def test_add_user(monkeypatch):
+    """`api.add_user` returns a `types.SnapdResponse`."""
+    mock_response = types.SnapdResponse(
+        type="sync",
+        status_code=200,
+        status="OK",
+        result=[
+            {
+                "username": "john-doe",
+                "ssh-keys": [
+                    "ssh-ed25519 some-ssh-key john@localhost # "
+                    'snapd {"origin":"store","email":"john.doe@example.com"}'
+                ],
+            }
+        ],
+    )
+
+    def mock_post(path, body):
+        assert path == "/users"
+
+        return mock_response
+
+    monkeypatch.setattr(http, "post", mock_post)
+
+    result = api.add_user(
+        username="john-doe", email="john.doe@example.com", force_managed=True
+    )
+    assert result == mock_response
+
+
+def test_add_user_exception(monkeypatch):
+    """`api.add_user` raises a `http.SnapdHttpException`."""
+
+    def mock_post(path, body):
+        assert path == "/users"
+
+        raise http.SnapdHttpException(
+            {"message": "cannot create user: device already managed"}
+        )
+
+    monkeypatch.setattr(http, "post", mock_post)
+
+    with pytest.raises(http.SnapdHttpException):
+        api.add_user(username="john-doe", email="john.doe@example.com")
+
+
+def test_remove_user(monkeypatch):
+    """`api.remove_user` returns a `types.SnapdResponse`."""
+    mock_response = types.SnapdResponse(
+        type="sync",
+        status_code=200,
+        status="OK",
+        result={
+            "removed": [
+                {"id": 4, "username": "john-doe", "email": "john.doe@example.com"}
+            ]
+        },
+    )
+
+    def mock_post(path, body):
+        assert path == "/users"
+
+        return mock_response
+
+    monkeypatch.setattr(http, "post", mock_post)
+
+    result = api.remove_user(username="john-doe")
+    assert result == mock_response
+
+
+def test_remove_user_exception(monkeypatch):
+    """`api.remove_user` raises a `http.SnapdHttpException`."""
+
+    def mock_post(path, body):
+        assert path == "/users"
+
+        raise http.SnapdHttpException(
+            {"message":"user \"jane-doe\" is not known"}
+        )
+
+    monkeypatch.setattr(http, "post", mock_post)
+
+    with pytest.raises(http.SnapdHttpException):
+        api.remove_user(username="jane-doe")

--- a/tox.ini
+++ b/tox.ini
@@ -15,4 +15,4 @@ commands_pre =
     poetry install
 commands =
     poetry run pytest tests/unit --cov snap_http/ --cov-branch \
-        --cov-report term-missing --cov-fail-under 92 --import-mode importlib
+        --cov-report term-missing --cov-fail-under 93 --import-mode importlib


### PR DESCRIPTION
Didn't add integration tests because user administration is only allowed on Core devices but we develop and test on Ubuntu classic.

Source: https://forum.snapcraft.io/t/snapd-users-api-on-ubuntu-classic/36928