### PR TITLE
fix: handle warnings in snapd response

### DIFF
--- a/snap_http/http.py
+++ b/snap_http/http.py
@@ -1,9 +1,10 @@
 """Lower-level functions for making actual HTTP requests to snapd's REST API."""
 import json
 import socket
+from functools import cached_property
 from http.client import HTTPResponse, responses
 from io import BytesIO
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 from urllib.parse import urlencode
 
 from .types import JsonData, SnapdRequestBody, SnapdResponse
@@ -14,6 +15,16 @@ SNAPD_SOCKET = "/run/snapd.socket"
 
 class SnapdHttpException(Exception):
     """An exception raised during HTTP communication with snapd."""
+
+    @cached_property
+    def json(self) -> Union[Dict, None]:
+        """Attempts to parse the body of this exception as json."""
+        result = None
+        if self.args:
+            body = self.args[0]
+            result = json.loads(body)
+
+        return result
 
 
 def get(path: str, **kwargs: Any) -> SnapdResponse:

--- a/snap_http/types.py
+++ b/snap_http/types.py
@@ -37,6 +37,8 @@ class SnapdResponse:
     result: Union[Dict[str, Any], List[Any]]
     sources: Union[List[str], None] = None
     change: Union[str, None] = None
+    warning_timestamp: Union[str, None] = None
+    warning_count: Union[int, None] = None
 
     @classmethod
     def from_http_response(cls: Type, response: Dict[str, Any]) -> SnapdResponse:


### PR DESCRIPTION
This PR:

- handles warnings in `SnapdResponse`
- adds a method to parse `SnapdHttpException` body to json (picked from the previous `landscape_client` snapd integration)
- updates `test_put_exception` with a more realistic test case

I ran into a peculiar case where the snapd API started returning warnings since the virtual device had ran out of space:

```console
$ snap_http.list_users()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/snap/landscape-client/x8/usr/lib/python3/dist-packages/landscape/client/snap_http/api.py", line 330, in list_users
    return http.get("/users")
  File "/snap/landscape-client/x8/usr/lib/python3/dist-packages/landscape/client/snap_http/http.py", line 23, in get
    return SnapdResponse.from_http_response(response)
  File "/snap/landscape-client/x8/usr/lib/python3/dist-packages/landscape/client/snap_http/types.py", line 43, in from_http_response
    return cls(**{k.replace("-", "_"): v for k, v in response.items()})
TypeError: SnapdResponse.__init__() got an unexpected keyword argument 'warning_timestamp'

$ snap_http.http._make_request("/users", "GET")
{'type': 'sync', 'status-code': 200, 'status': 'OK', 'result': [], 'warning-timestamp': '2024-02-08T10:40:14.402267838Z', 'warning-count': 1}

$ snap warnings  # inside `sudo snap run --shell landscape-client`
last-occurrence:  today at 10:40 UTC
warning: |
  seeding failed with: no seed assertions. This indicates an error in your distribution, please see
  https://forum.snapcraft.io/t/16341 for more information.

$ snap warnings  # outside `sudo snap run --shell landscape-client`
error: write /home/st3v3nmw/.snap/warnings.json.fh7Y3TqHJf9L~: no space left on device
```